### PR TITLE
Dump of accumulated changes.

### DIFF
--- a/rome/colosseum/workload_driver.h
+++ b/rome/colosseum/workload_driver.h
@@ -129,10 +129,10 @@ absl::Status WorkloadDriver<OpType>::Start() {
     return absl::UnavailableError(
         "Cannot restart a terminated workload driver.");
   }
-  stopwatch_ = metrics::Stopwatch::Create("driver_stopwatch");
   auto client_status = client_->Start();
   if (!client_status.ok()) return client_status;
 
+  stopwatch_ = metrics::Stopwatch::Create("driver_stopwatch");
   auto task =
       std::packaged_task<absl::Status()>(std::bind(&WorkloadDriver::Run, this));
   run_status_ = task.get_future();

--- a/rome/logging/logging.h
+++ b/rome/logging/logging.h
@@ -90,9 +90,9 @@ inline void __rome_init_log__() {
 #endif
 
 #if ROME_LOG_LEVEL != OFF
-#define ROME_FATAL(...)          \
-  SPDLOG_CRITICAL(__VA_ARGS__);  \
-  exit(1);
+#define ROME_FATAL(...)         \
+  SPDLOG_CRITICAL(__VA_ARGS__); \
+  abort();
 #endif
 
 #define ROME_RETURN(x) [&]() { return x; }
@@ -121,10 +121,10 @@ inline void __rome_init_log__() {
     SPDLOG_CRITICAL(__VA_ARGS__); \
     abort();                      \
   }
-#define ROME_ASSERT_OK(status)                                 \
-  if (!(status.ok())) [[unlikely]] {                           \
-    SPDLOG_CRITICAL(::testutil::GetStatus(status).ToString()); \
-    abort();                                                   \
+#define ROME_ASSERT_OK(status)                              \
+  if (auto __s = status; !(__s.ok())) [[unlikely]] {        \
+    SPDLOG_CRITICAL(::testutil::GetStatus(__s).ToString()); \
+    abort();                                                \
   }
 
 // Specific checks for debugging. Can be turned off by commenting out

--- a/rome/metrics/metric.h
+++ b/rome/metrics/metric.h
@@ -18,7 +18,7 @@ class Metric {
   };
 
  protected:
-  std::string name_;
+  const std::string name_;
 };
 
 template <typename T>

--- a/rome/rdma/BUILD
+++ b/rome/rdma/BUILD
@@ -9,6 +9,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "rdma_util_test",
+    srcs = ["rdma_util_test.cc"],
+    deps = [
+        ":rdma_util",
+        "@gtest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rdma_device",
     srcs = ["rdma_device.cc"],

--- a/rome/rdma/channel/BUILD
+++ b/rome/rdma/channel/BUILD
@@ -56,3 +56,14 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "sync_accessor",
+    srcs = ["sync_accessor.cc"],
+    hdrs = ["sync_accessor.h"],
+    deps = [
+        ":rdma_accessor",
+        "//rome/rdma:rdma_util",
+        "@absl//absl/status",
+    ],
+)

--- a/rome/rdma/channel/rdma_accessor.h
+++ b/rome/rdma/channel/rdma_accessor.h
@@ -9,14 +9,16 @@ namespace rome {
 class RdmaAccessor {
  public:
   virtual ~RdmaAccessor() = default;
-  virtual absl::Status Placeholder() = 0;
+  virtual absl::Status PostInternal(ibv_send_wr* sge, ibv_send_wr** bad) = 0;
 };
 
 class EmptyRdmaAccessor : public RdmaAccessor {
  public:
   ~EmptyRdmaAccessor() = default;
   explicit EmptyRdmaAccessor(rdma_cm_id* id) {}
-  absl::Status Placeholder() override { return absl::OkStatus(); }
+  absl::Status PostInternal(ibv_send_wr* sge, ibv_send_wr** bad) override {
+    return absl::OkStatus();
+  }
 };
 
 }  // namespace rome

--- a/rome/rdma/channel/rdma_channel.h
+++ b/rome/rdma/channel/rdma_channel.h
@@ -49,6 +49,10 @@ class RdmaChannel : public Messenger, Accessor {
     }
   }
 
+  absl::Status Post(ibv_send_wr* wr, ibv_send_wr** bad) {
+    return this->PostInternal(wr, bad);
+  }
+
  private:
   // A pointer to the QP used to post sends and receives.
   rdma_cm_id* id_;  //! NOT OWNED

--- a/rome/rdma/channel/sync_accessor.cc
+++ b/rome/rdma/channel/sync_accessor.cc
@@ -1,0 +1,37 @@
+#include "sync_accessor.h"
+
+#include <asm-generic/errno-base.h>
+#include <infiniband/verbs.h>
+
+#include "rome/logging/logging.h"
+#include "rome/rdma/rdma_util.h"
+#include "rome/util/status_util.h"
+
+namespace rome {
+
+using ::util::InternalErrorBuilder;
+
+SyncRdmaAccessor::SyncRdmaAccessor(rdma_cm_id *id) : id_(id) {}
+
+absl::Status SyncRdmaAccessor::PostInternal(ibv_send_wr *wr,
+                                            ibv_send_wr **bad) {
+  *bad = nullptr;
+  RDMA_CM_CHECK(ibv_post_send, id_->qp, wr, bad);
+  if (*bad != nullptr) {
+    ROME_FATAL("WTF");
+  }
+
+  ibv_wc wc;
+  auto ret = ibv_poll_cq(id_->send_cq, 1, &wc);
+  while (ret == 0 || (ret < 0 && errno == EAGAIN)) {
+    ret = ibv_poll_cq(id_->send_cq, 1, &wc);
+  }
+  ROME_CHECK_QUIET(ROME_RETURN(InternalErrorBuilder()
+                               << "ibv_poll_cq(): "
+                               << (ret < 0 ? strerror(errno)
+                                           : ibv_wc_status_str(wc.status))),
+                   ret == 1 && wc.status == IBV_WC_SUCCESS);
+  return absl::OkStatus();
+}
+
+}  // namespace rome

--- a/rome/rdma/channel/sync_accessor.h
+++ b/rome/rdma/channel/sync_accessor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <infiniband/verbs.h>
+
+#include "rome/rdma/channel/rdma_accessor.h"
+#include "rome/rdma/rdma_util.h"
+
+namespace rome {
+
+class SyncRdmaAccessor : public RdmaAccessor {
+ public:
+  ~SyncRdmaAccessor() = default;
+  explicit SyncRdmaAccessor(rdma_cm_id* id);
+  absl::Status PostInternal(ibv_send_wr* wr, ibv_send_wr** bad) override;
+
+ private:
+  rdma_cm_id* id_;  //! NOT OWNED
+};
+
+}  // namespace rome

--- a/rome/rdma/channel/twosided_messenger_impl.h
+++ b/rome/rdma/channel/twosided_messenger_impl.h
@@ -25,7 +25,8 @@ TwoSidedRdmaMessenger<kCapacity, kRecvMaxBytes>::TwoSidedRdmaMessenger(
       recv_capacity_(kCapacity / 2),
       recv_total_(0) {
   ROME_ASSERT_OK(rm_.RegisterMemoryRegion(kSendId, 0, send_capacity_));
-  ROME_ASSERT_OK(rm_.RegisterMemoryRegion(kRecvId, 0, recv_capacity_));
+  ROME_ASSERT_OK(
+      rm_.RegisterMemoryRegion(kRecvId, send_capacity_, recv_capacity_));
   send_mr_ = VALUE_OR_DIE(rm_.GetMemoryRegion(kSendId));
   recv_mr_ = VALUE_OR_DIE(rm_.GetMemoryRegion(kRecvId));
   send_base_ = reinterpret_cast<uint8_t*>(send_mr_->addr);

--- a/rome/rdma/rdma_broker.h
+++ b/rome/rdma/rdma_broker.h
@@ -49,9 +49,9 @@ class RdmaBroker {
   // `receiver`. If the initialization fails, then the status is propagated to
   // the caller. Otherwise, a unique pointer to the newly created `RdmaBroker`
   // is returned.
-  static std::unique_ptr<RdmaBroker> Create(std::string_view device,
-                                            std::optional<uint16_t> port,
-                                            RdmaReceiverInterface* receiver);
+  static std::unique_ptr<RdmaBroker> Create(
+      std::optional<std::string_view> device, std::optional<uint16_t> port,
+      RdmaReceiverInterface* receiver);
 
   RdmaBroker(const RdmaBroker&) = delete;
   RdmaBroker(RdmaBroker&&) = delete;
@@ -70,12 +70,14 @@ class RdmaBroker {
 
   // Start the broker listening on the given `device` and `port`. If `port` is
   // `nullopt`, then the first available port is used.
-  absl::Status Init(std::string_view addr, std::optional<uint16_t> port);
+  absl::Status Init(std::optional<std::string_view> addr,
+                    std::optional<uint16_t> port);
 
   Coro HandleConnectionRequests();
 
   void Run();
 
+  std::string name_;
   std::string address_;
   uint16_t port_;
 

--- a/rome/rdma/rdma_device.cc
+++ b/rome/rdma/rdma_device.cc
@@ -67,6 +67,15 @@ RdmaDevice::GetAvailableDevices() {
   return active;
 }
 
+/* static */ absl::Status RdmaDevice::LookupDevice(std::string_view name) {
+  auto devices_or = GetAvailableDevices();
+  if (!devices_or.ok()) return devices_or.status();
+  for (const auto &d : devices_or.value()) {
+    if (name == d.first) return absl::OkStatus();
+  }
+  return util::NotFoundErrorBuilder() << "Device not found: " << name;
+}
+
 RdmaDevice::~RdmaDevice() { protection_domains_.clear(); }
 
 absl::Status RdmaDevice::OpenDevice(std::string_view dev_name) {

--- a/rome/rdma/rdma_device.h
+++ b/rome/rdma/rdma_device.h
@@ -21,6 +21,8 @@ class RdmaDevice {
   static absl::StatusOr<std::vector<std::pair<std::string, int>>>
   GetAvailableDevices();
 
+  static absl::Status LookupDevice(std::string_view name);
+
   static std::unique_ptr<RdmaDevice> Create(std::string_view name,
                                             std::optional<int> port) {
     auto *device = new RdmaDevice();

--- a/rome/rdma/rdma_util.h
+++ b/rome/rdma/rdma_util.h
@@ -2,6 +2,7 @@
 
 #include <infiniband/verbs.h>
 
+#include <cstdio>
 #include <memory>
 
 #include "rome/logging/logging.h"
@@ -42,3 +43,38 @@ struct ibv_mr_deleter {
   void operator()(ibv_mr *mr) { ibv_dereg_mr(mr); }
 };
 using ibv_mr_unique_ptr = std::unique_ptr<ibv_mr, ibv_mr_deleter>;
+
+static absl::StatusOr<std::string> ibdev2netdev(std::string_view dev_name) {
+  std::array<char, 1024> buffer;
+  std::string result;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("ibdev2netdev", "r"),
+                                                pclose);
+  ROME_ASSERT(pipe != nullptr, "Failed open pipe: ibdev2netdev");
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    result += buffer.data();
+  }
+
+  auto split = [](std::string_view str, char delim) {
+    std::vector<std::string> tokens;
+    size_t start = 0, end = str.find(delim);
+    while (end != std::string::npos) {
+      tokens.emplace_back(str.substr(start, end - start));
+      start = end + 1;
+      end = str.find(delim, start);
+    }
+    return tokens;
+  };
+
+  if (!result.empty()) {
+    auto lines = split(result, '\n');
+    for (const auto &l : lines) {
+      auto line = split(l, ' ');
+      // Expected: ["mlx5_0","port","1","==>","ibp153s0","(Up)"]
+      if (line[0] == dev_name) {
+        return line[4];
+      }
+    }
+  }
+  return util::NotFoundErrorBuilder()
+         << "Device address not found: " << dev_name;
+}

--- a/rome/rdma/rdma_util_test.cc
+++ b/rome/rdma/rdma_util_test.cc
@@ -1,0 +1,12 @@
+#include "rdma_util.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+TEST(ibdev2netdevTest, Test) {
+  // Test plan: Try it out bro!
+  auto result = ibdev2netdev("mlx5_0");
+  EXPECT_OK(result);
+  EXPECT_EQ(result.value(), "ibp153s0");
+  EXPECT_TRUE(true);
+}

--- a/rome/util/BUILD
+++ b/rome/util/BUILD
@@ -89,3 +89,19 @@ cc_library(
     hdrs = ["memory_resource.h"],
     deps = [],
 )
+
+cc_library(
+    name = "variant_util",
+    hdrs = ["variant_util.h"],
+    deps = [],
+)
+
+cc_test(
+    name = "variant_util_test",
+    srcs = ["variant_util_test.cc"],
+    deps = [
+        ":variant_util",
+        "//rome/logging",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/rome/util/variant_util.h
+++ b/rome/util/variant_util.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace rome {
+
+// https://stackoverflow.com/questions/57726401/stdvariant-vs-inheritance-vs-other-ways-performance
+//
+// This particular implementation of `visit` is copied from the above
+// discussion. When the visitor cannot throw an exception, this code provides
+// extremely fast visitation since it eliminates expection catching code. That
+// said, if exceptions are possible then it is probably preferred to use a
+// lambda that has the following structure:
+//
+// std::visit([](const auto& v) {
+//   using type = std::decay_t<decltype(v)>;
+//   if constexpr (std::is_same_v<type, A>) { } 
+//   else if (std::is_same_v<type, B>) { }
+//   else { } }, var);
+
+template <typename... Fs>
+struct overload : Fs... {
+  using Fs::operator()...;
+};
+
+template <typename... Fs>
+overload(Fs...) -> overload<Fs...>;
+
+template <size_t N, typename R, typename Variant, typename Visitor>
+[[nodiscard]] constexpr R visit(Variant &&var, Visitor &&vis) {
+  if constexpr (N == 0) {
+    if (N == var.index()) {
+      return std::forward<Visitor>(vis)(
+          std::get<0>(std::forward<Variant>(var)));
+    }
+  } else {
+    if (var.index() == N) {
+      return std::forward<Visitor>(vis)(
+          std::get<N>(std::forward<Variant>(var)));
+    }
+    return visit<N - 1, R>(std::forward<Variant>(var),
+                           std::forward<Visitor>(vis));
+  }
+  while (true)  // Avoids compilers complaints (-Wreturn-type)
+    ;
+}
+
+template <class... Args, typename Visitor, typename... Visitors>
+[[nodiscard]] constexpr decltype(auto) visit(std::variant<Args...> const &var,
+                                             Visitor &&vis,
+                                             Visitors &&...visitors) {
+  auto ol =
+      overload{std::forward<Visitor>(vis), std::forward<Visitors>(visitors)...};
+  using result_t = decltype(std::invoke(std::move(ol), std::get<0>(var)));
+
+  static_assert(sizeof...(Args) > 0);
+  return visit<sizeof...(Args) - 1, result_t>(var, std::move(ol));
+}
+
+template <class... Args, typename Visitor, typename... Visitors>
+[[nodiscard]] constexpr decltype(auto) visit(std::variant<Args...> &var,
+                                             Visitor &&vis,
+                                             Visitors &&...visitors) {
+  auto ol =
+      overload{std::forward<Visitor>(vis), std::forward<Visitors>(visitors)...};
+  using result_t = decltype(std::invoke(std::move(ol), std::get<0>(var)));
+
+  static_assert(sizeof...(Args) > 0);
+  return visit<sizeof...(Args) - 1, result_t>(var, std::move(ol));
+}
+
+template <class... Args, typename Visitor, typename... Visitors>
+[[nodiscard]] constexpr decltype(auto) visit(std::variant<Args...> &&var,
+                                             Visitor &&vis,
+                                             Visitors &&...visitors) {
+  auto ol =
+      overload{std::forward<Visitor>(vis), std::forward<Visitors>(visitors)...};
+  using result_t =
+      decltype(std::invoke(std::move(ol), std::move(std::get<0>(var))));
+
+  static_assert(sizeof...(Args) > 0);
+  return visit<sizeof...(Args) - 1, result_t>(std::move(var), std::move(ol));
+}
+
+template <typename Value, typename... Visitors>
+inline constexpr bool is_visitable_v = (std::is_invocable_v<Visitors, Value> or
+                                        ...);
+
+}  // namespace rome

--- a/rome/util/variant_util_test.cc
+++ b/rome/util/variant_util_test.cc
@@ -1,0 +1,51 @@
+#include "variant_util.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "rome/logging/logging.h"
+
+namespace rome {
+namespace {
+
+struct A {
+  std::string s = "A";
+};
+
+struct B {
+  std::string s = "B";
+};
+
+struct C {
+  std::string s = "C";
+};
+
+TEST(VariantUtilTest, Test) {
+  ROME_INIT_LOG();
+  // Test plan:
+  std::variant<A, B, C> var;
+  var = A();
+  auto o = overload{
+      [](A& a) {
+        ROME_INFO("{}", a.s);
+        return true;
+      },
+      [](B& b) {
+        ROME_INFO("{}", b.s);
+        return true;
+      },
+      [](C& c) {
+        ROME_INFO("{}", c.s);
+        return true;
+      },
+  };
+  EXPECT_TRUE(visit(var, o));
+
+  var = B();
+  EXPECT_TRUE(visit(var, o));
+  var = C();
+  EXPECT_TRUE(visit(var, o));
+  EXPECT_TRUE(true);
+}
+
+}  // namespace
+}  // namespace rome

--- a/scripts/setup/config.ini
+++ b/scripts/setup/config.ini
@@ -1,5 +1,5 @@
 [workspace]
-root = <replace>
+root = /home/jacob/sss/rome
 third_party_root = ${root}/scripts/third_party
 env_file = .romerc
 


### PR DESCRIPTION
Some highlights are:
1) Added a high-performance custom `std::variant` visitor, does not catch exceptions
2) Updated `RdmaBroker` to take a `std::nullopt` for the device (Fixes jacnel/projec-x#9)
3) Provide C++ wrapper for `ibdev2netdev` for a given device name
4) Small house cleaning and bug fixes